### PR TITLE
Switch to more lightweight API call for alive check

### DIFF
--- a/matterclient.go
+++ b/matterclient.go
@@ -532,7 +532,7 @@ func (m *Client) wsConnect() {
 }
 
 func (m *Client) doCheckAlive() error {
-	if _, _, err := m.Client.GetMe(""); err != nil {
+	if _, _, err := m.Client.GetPing(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Use the same as the Mattermost clients.