### PR TITLE
Add support for logging Mattermost API calls

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -21,6 +21,7 @@ func (m *Client) GetChannel(ctx context.Context, channelID string) *model.Channe
 	}
 
 	query := "/channels/" + channelID
+	m.apiLogger.Warnf("GetChannel: DoAPIGet: query %s", query)
 	resp, err := m.Client.DoAPIGet(ctx, query, "")
 	if err != nil {
 		return nil
@@ -114,6 +115,7 @@ func (m *Client) getChannelIDTeam(name string, teamID string) string {
 	m.Users.mu.RUnlock()
 
 	query := "/teams/" + teamID + "/channels/name/" + name
+	m.apiLogger.Warnf("getChannelIDTeam: DoAPIGet: query %s", query)
 	resp, err := m.Client.DoAPIGet(context.TODO(), query, "")
 	if err != nil {
 		return ""
@@ -181,6 +183,7 @@ func (m *Client) GetChannelUsers(channelID string) ([]*model.User, error) {
 	retryCount := 0
 	for {
 		query := "/users?in_channel=" + channelID + "&page=" + strconv.Itoa(idx) + "&per_page=" + strconv.Itoa(batchSize)
+		m.apiLogger.Warnf("GetChannelUsers: DoAPIGet: query %s #%d", query, retryCount)
 		resp, err := m.Client.DoAPIGet(context.TODO(), query, "")
 		if err != nil {
 			var mResp *model.Response
@@ -296,6 +299,7 @@ func (m *Client) GetLastViewedAt(channelID string) int64 {
 
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("GetLastViewedAt: ChannelID: %s, UserID: %s #%d", channelID, userID, retryCount)
 		res, resp, err := m.Client.GetChannelMember(context.TODO(), channelID, userID, "")
 		if err == nil {
 			viewedAt := res.LastViewedAt
@@ -377,6 +381,7 @@ func (m *Client) JoinChannel(channelID string) error {
 
 	m.logger.Debug("Joining ", channelID)
 
+	m.apiLogger.Warnf("JoinChannel: ChannelID: %s, UserID: %s", channelID, m.User.Id)
 	_, _, err := m.Client.AddChannelMember(context.TODO(), channelID, m.User.Id)
 	if err != nil {
 		return err
@@ -410,6 +415,7 @@ func (m *Client) UpdateChannelsTeam(teamID string) error {
 	retryCount := 0
 	for {
 		query := "/users/" + m.User.Id + "/teams/" + teamID + "/channels"
+		m.apiLogger.Warnf("UpdateChannelsTeam: DoAPIGet: query %s #%d", query, retryCount)
 		resp, err := m.Client.DoAPIGet(ctx, query, "")
 		if err != nil {
 			var mResp *model.Response
@@ -439,6 +445,7 @@ func (m *Client) UpdateChannelsTeam(teamID string) error {
 	retryCount = 0
 	for {
 		query := "/teams/" + teamID + "/channels?page=" + strconv.Itoa(idx) + "&per_page=" + strconv.Itoa(batchSize)
+		m.apiLogger.Warnf("UpdateChannelsTeam: DoAPIGet: query %s #%d", query, retryCount)
 		resp, err := m.Client.DoAPIGet(ctx, query, "")
 		if err != nil {
 			var mResp *model.Response
@@ -602,6 +609,7 @@ func (m *Client) UpdateChannelHeader(channelID string, header string) {
 
 	m.logger.Debugf("updating channelheader %#v, %#v", channelID, header)
 
+	m.apiLogger.Warnf("UpdateChannelHeader: ChannelID: %s", channelID)
 	_, _, err := m.Client.UpdateChannel(context.TODO(), channel)
 	if err != nil {
 		m.logger.Error(err)
@@ -637,6 +645,7 @@ func (m *Client) UpdateLastViewed(channelID string) error {
 
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("UpdateLastViewed: ChannelID: %s, UserID: %s #%d", channelID, m.User.Id, retryCount)
 		_, resp, err := m.Client.ViewChannel(context.TODO(), m.User.Id, view)
 		if err == nil {
 			return nil

--- a/matterclient.go
+++ b/matterclient.go
@@ -128,6 +128,10 @@ type Client struct {
 
 	logger      *logrus.Entry
 	rootLogger  *logrus.Logger
+
+	apiLogger      *logrus.Entry
+	rootAPILogger  *logrus.Logger
+
 	lruCache    *lru.Cache[string, bool]
 	aliveChan   chan bool
 	loginCancel context.CancelFunc
@@ -139,12 +143,22 @@ type Client struct {
 var Matterircd bool
 
 func New(login string, pass string, team string, server string, mfatoken string) *Client {
+	// Logger for the rest of matterclient
 	rootLogger := logrus.New()
 	rootLogger.SetFormatter(&prefixed.TextFormatter{
 		PrefixPadding: 13,
 		DisableColors: false,
 		FullTimestamp: true,
 	})
+	// Logger for Mattermost API calls
+	rootAPILogger := logrus.New()
+	rootAPILogger.SetFormatter(&prefixed.TextFormatter{
+		PrefixPadding: 21,
+		DisableColors: false,
+		FullTimestamp: true,
+	})
+	// Default to higher than "warn" to not log anything
+	rootAPILogger.SetLevel(logrus.ErrorLevel)
 
 	cred := &Credentials{
 		Login:    login,
@@ -170,9 +184,14 @@ func New(login string, pass string, team string, server string, mfatoken string)
 
 			channelLastViewedAt: make(map[string]int64, 1000),
 		},
-		rootLogger: rootLogger,
 		lruCache:   cache,
+
+		rootLogger: rootLogger,
 		logger:     rootLogger.WithFields(logrus.Fields{"prefix": "matterclient"}),
+
+		rootAPILogger: rootAPILogger,
+		apiLogger:     rootAPILogger.WithFields(logrus.Fields{"prefix": "matterclient: MM API"}),
+
 		aliveChan:  make(chan bool),
 	}
 }
@@ -385,6 +404,7 @@ func (m *Client) serverAlive(b *backoff.Backoff) error {
 	for {
 		d := b.Duration()
 		// bogus call to get the serverversion
+		m.apiLogger.Info("serverAlive: Logout")
 		resp, err := m.Client.Logout(context.TODO())
 		if err != nil {
 			return err
@@ -419,6 +439,7 @@ func (m *Client) initUser() error {
 	for {
 		var resp *model.Response
 		var err error
+		m.apiLogger.Warnf("initUser: GetTeamsForUser: UserID %s #%d", userID, retryCount)
 		teams, resp, err = m.Client.GetTeamsForUser(ctx, userID, "")
 		if err == nil {
 			break
@@ -458,6 +479,7 @@ func (m *Client) initUser() error {
 		pageRetryCount := 0
 		for {
 			query := "/users?in_team=" + team.Id + "&page=" + strconv.Itoa(idx) + "&per_page=" + strconv.Itoa(batchSize)
+			m.apiLogger.Warnf("initUser: DoAPIGet: query %s #%d", query, retryCount)
 			resp, err := m.Client.DoAPIGet(context.TODO(), query, "")
 			if err != nil {
 				var mResp *model.Response
@@ -623,8 +645,10 @@ func (m *Client) doLogin(firstConnection bool, b *backoff.Backoff) error {
 				return err
 			}
 		case m.Credentials.MFAToken != "":
+			m.apiLogger.Info("doLogin: LoginWithMFA")
 			user, _, err = m.Client.LoginWithMFA(ctx, m.Credentials.Login, m.Credentials.Pass, m.Credentials.MFAToken)
 		default:
+			m.apiLogger.Info("doLogin: Login")
 			user, _, err = m.Client.Login(ctx, m.Credentials.Login, m.Credentials.Pass)
 		}
 
@@ -674,6 +698,7 @@ func (m *Client) doLoginToken() (*model.User, *model.Response, error) {
 		m.logger.Debugf(logmsg + " with personal token")
 	}
 
+	m.apiLogger.Info("doLoginToken: GetMe")
 	user, resp, err = m.Client.GetMe(context.TODO(), "")
 	if err != nil {
 		return user, resp, err
@@ -793,6 +818,7 @@ func (m *Client) doCheckAlive(ctx context.Context) error {
 	}
 
 	m.logger.Tracef("websocket has been quiet (last event %v ago; up %s), falling back to HTTP GetPing", timeSinceActivity.Round(time.Second), uptime)
+	m.apiLogger.Info("doCheckAlive: GetPing")
 	if _, _, err := m.Client.GetPing(ctx); err != nil {
 		m.logger.Warnf("fallback HTTP ping failed (up %s): %s", uptime, err)
 		return fmt.Errorf("fallback HTTP ping failed (up %s): %w", uptime, err)
@@ -995,6 +1021,7 @@ func (m *Client) Logout() error {
 	// actually log out
 	m.logger.Debug("running m.Client.Logout")
 
+	m.apiLogger.Info("Logout")
 	if _, err := m.Client.Logout(context.TODO()); err != nil {
 		return err
 	}
@@ -1002,6 +1029,18 @@ func (m *Client) Logout() error {
 	m.logger.Debug("exiting Logout()")
 
 	return nil
+}
+
+// SetLogLevel tries to parse the specified level and if successful sets
+// the log level accordingly. Accepted levels are: 'debug', 'info', 'warn',
+// 'error', 'fatal' and 'panic'.
+func (m *Client) SetLogAPICalls(level string) {
+	l, err := logrus.ParseLevel(level)
+	if err != nil {
+		m.logger.Warnf("Failed to parse specified log-level '%s': %#v", level, err)
+	} else {
+		m.rootAPILogger.SetLevel(l)
+	}
 }
 
 // SetLogLevel tries to parse the specified level and if successful sets
@@ -1142,6 +1181,7 @@ func (m *Client) syncSingleUser(ctx context.Context, event *model.WebSocketEvent
 		return
 	}
 
+	m.apiLogger.Warnf("syncSingleUser: GetUser: UserID: %s", userID)
 	user, _, err := m.Client.GetUser(ctx, userID, "")
 	if err != nil {
 		m.logger.Errorf("syncSingleUser failed to get user %s: %v", userID, err)

--- a/matterclient.go
+++ b/matterclient.go
@@ -1031,9 +1031,9 @@ func (m *Client) Logout() error {
 	return nil
 }
 
-// SetLogLevel tries to parse the specified level and if successful sets
-// the log level accordingly. Accepted levels are: 'debug', 'info', 'warn',
-// 'error', 'fatal' and 'panic'.
+// SetLogAPICalls sets the log level of the Mattermost API-call logger.
+// Set to "warn" to log most API request operations (some lifecycle calls are logged at "info").
+// Accepted levels are: 'debug', 'info', 'warn', 'error', 'fatal' and 'panic'.
 func (m *Client) SetLogAPICalls(level string) {
 	l, err := logrus.ParseLevel(level)
 	if err != nil {

--- a/messages.go
+++ b/messages.go
@@ -23,6 +23,7 @@ func (m *Client) parseResponse(rmsg *model.WebSocketResponse) {
 func (m *Client) CreatePost(post *model.Post) (*model.Post, error) {
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("CreatePost: UserID: %s, ChannelID: %s #%d", post.UserId, post.ChannelId, retryCount)
 		res, resp, err := m.Client.CreatePost(context.TODO(), post)
 		if err == nil {
 			return res, nil
@@ -39,6 +40,7 @@ func (m *Client) CreatePost(post *model.Post) (*model.Post, error) {
 }
 
 func (m *Client) DeleteMessage(postID string) error {
+	m.apiLogger.Warnf("DeleteMessage: PostID: %s", postID)
 	_, err := m.Client.DeletePost(context.TODO(), postID)
 	if err != nil {
 		return err
@@ -50,6 +52,7 @@ func (m *Client) DeleteMessage(postID string) error {
 func (m *Client) EditMessage(postID string, text string) (string, error) {
 	post := &model.Post{Message: text, Id: postID}
 
+	m.apiLogger.Warnf("EditMessage: PostID: %s", postID)
 	res, _, err := m.Client.UpdatePost(context.TODO(), postID, post)
 	if err != nil {
 		return "", err
@@ -67,6 +70,7 @@ func (m *Client) GetFileLinks(filenames []string) []string {
 	var output []string
 
 	for _, f := range filenames {
+		m.apiLogger.Infof("GetFileLinks: file: %s", f)
 		res, _, err := m.Client.GetFileLink(context.TODO(), f)
 		if err != nil {
 			// public links is probably disabled, create the link ourselves
@@ -84,6 +88,7 @@ func (m *Client) GetFileLinks(filenames []string) []string {
 func (m *Client) GetPost(postID string) (*model.Post, error) {
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("GetPost: PostID: %s #%d", postID, retryCount)
 		res, resp, err := m.Client.GetPost(context.TODO(), postID, "")
 		if err == nil {
 			return res, nil
@@ -123,6 +128,7 @@ func (m *Client) GetPosts(channelID string, limit int) *model.PostList {
 			currentBatchSize = limit - fetched
 		}
 
+		m.apiLogger.Warnf("GetPosts: ChannelID: %s, Page: %d, PerPage: %d #%d", channelID, idx, currentBatchSize, retryCount)
 		res, resp, err := m.Client.GetPostsForChannel(context.TODO(), channelID, idx, currentBatchSize, "", false, false)
 		if err != nil {
 			shouldRetry, hErr := m.HandleRetry("GetPostsForChannel", retryCount, 10, resp)
@@ -168,6 +174,7 @@ func (m *Client) GetPostThread(postID string) *model.PostList {
 
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("GetPostThread: PostID: %s #%d", postID, retryCount)
 		res, resp, err := m.Client.GetPostThreadWithOpts(context.TODO(), postID, "", opts)
 		if err == nil {
 			return res
@@ -201,6 +208,7 @@ func (m *Client) GetPostsSince(channelID string, time int64) *model.PostList {
 
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("GetPostsSince: ChannelID: %s, Since: %d #%d", channelID, time, retryCount)
 		res, resp, err := m.Client.GetPostsSince(context.TODO(), channelID, time, false)
 		if err == nil {
 			return res
@@ -218,6 +226,7 @@ func (m *Client) GetPostsSince(channelID string, time int64) *model.PostList {
 }
 
 func (m *Client) GetPublicLink(filename string) string {
+	m.apiLogger.Infof("GetPublicLink: file: %s", filename)
 	res, _, err := m.Client.GetFileLink(context.TODO(), filename)
 	if err != nil {
 		return ""
@@ -230,6 +239,7 @@ func (m *Client) GetPublicLinks(filenames []string) []string {
 	var output []string
 
 	for _, f := range filenames {
+		m.apiLogger.Infof("GetPublicLinks: file: %s", f)
 		res, _, err := m.Client.GetFileLink(context.TODO(), f)
 		if err != nil {
 			continue
@@ -250,6 +260,7 @@ func (m *Client) PostMessage(channelID string, text string, rootID string) (stri
 
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("PostMessage: ChannelID: %s, RootID: %s #%d", channelID, rootID, retryCount)
 		res, resp, err := m.Client.CreatePost(context.TODO(), post)
 		if err == nil {
 			return res.Id, nil
@@ -275,6 +286,7 @@ func (m *Client) PostMessageWithFiles(channelID string, text string, rootID stri
 
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("PostMessageWithFiles: ChannelID: %s, RootID %s #%d", channelID, rootID, retryCount)
 		res, resp, err := m.Client.CreatePost(context.TODO(), post)
 		if err == nil {
 			return res.Id, nil
@@ -293,6 +305,7 @@ func (m *Client) PostMessageWithFiles(channelID string, text string, rootID stri
 func (m *Client) SearchPosts(query string) *model.PostList {
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("SearchPosts: query: %s #%d", query, retryCount)
 		res, resp, err := m.Client.SearchPosts(context.TODO(), m.Team.ID, query, false)
 		if err == nil {
 			return res
@@ -319,6 +332,7 @@ func (m *Client) SendDirectMessageProps(toUserID string, msg string, rootID stri
 	retryCount := 0
 	for {
 		// create DM channel (only happens on first message)
+		m.apiLogger.Warnf("SendDirectMessageProps: CreateDirectChannel: UserID: %s, toUserID: %s #%d", m.User.Id, toUserID, retryCount)
 		_, resp, err := m.Client.CreateDirectChannel(context.TODO(), m.User.Id, toUserID)
 		if err == nil {
 			break
@@ -353,6 +367,7 @@ func (m *Client) SendDirectMessageProps(toUserID string, msg string, rootID stri
 
 	retryCount = 0
 	for {
+		m.apiLogger.Warnf("SendDirectMessageProps: CreatePost: UserID: %s, ChannelID: %s #%d", post.UserId, post.ChannelId, retryCount)
 		_, resp, err := m.Client.CreatePost(context.TODO(), post)
 		if err == nil {
 			return nil
@@ -370,6 +385,7 @@ func (m *Client) SendDirectMessageProps(toUserID string, msg string, rootID stri
 }
 
 func (m *Client) UploadFile(data []byte, channelID string, filename string) (string, error) {
+	m.apiLogger.Warnf("UploadFile: ChannelID: %s, filename: %s", channelID, filename)
 	f, _, err := m.Client.UploadFile(context.TODO(), data, channelID, filename)
 	if err != nil {
 		return "", err

--- a/users.go
+++ b/users.go
@@ -25,6 +25,7 @@ func (m *Client) GetStatus(userID string) string {
 	m.Users.mu.RUnlock()
 
 	if !ok {
+		m.apiLogger.Warnf("GetStatus: GetUserStatus: UserID: %s", userID)
 		res, _, err := m.Client.GetUserStatus(context.TODO(), userID, "")
 		if err != nil {
 			status = "offline"
@@ -91,6 +92,7 @@ func (m *Client) GetStatuses() map[string]string {
 		}
 
 		batch := missingIDs[i:end]
+		m.apiLogger.Warnf("GetStatuses: GetUsersStatusesByIds: Batch: %d #%d", len(batch), i)
 		res, _, err := m.Client.GetUsersStatusesByIds(context.TODO(), batch)
 		if err != nil {
 			continue
@@ -138,6 +140,7 @@ func (m *Client) GetUser(ctx context.Context, userID string) *model.User {
 		return user
 	}
 
+	m.apiLogger.Warnf("GetUser: UserID: %s", userID)
 	res, _, err := m.Client.GetUser(ctx, userID, "")
 	if err != nil {
 		m.logger.Debugf("GetUser failed to fetch missing user %s: %s", userID, err)
@@ -241,6 +244,7 @@ func (m *Client) UpdateUsers() error {
 	retryCount := 0
 	for {
 		query := "/users?page=" + strconv.Itoa(idx) + "&per_page=" + strconv.Itoa(batchSize)
+		m.apiLogger.Warnf("UpdateUsers: DoAPIGet: query %s #%d", query, retryCount)
 		resp, err := m.Client.DoAPIGet(context.TODO(), query, "")
 		if err != nil {
 			var mResp *model.Response
@@ -328,6 +332,7 @@ func (m *Client) UpdateUserNick(nick string) error {
 	m.RUnlock()
 	userClone.Nickname = nick
 
+	m.apiLogger.Warnf("UpdateUserNick: nick: %s", nick)
 	updatedUser, _, err := m.Client.UpdateUser(context.TODO(), &userClone)
 	if err != nil {
 		return err
@@ -350,6 +355,7 @@ func (m *Client) UsernamesInChannel(channelID string) []string {
 	idx := 0
 	retryCount := 0
 	for {
+		m.apiLogger.Warnf("UsernamesInChannel: GetChannelMembers: ChannelID: %s, Page: %d, PerPage: %d #%d", channelID, idx, batchSize, retryCount)
 		res, resp, err := m.Client.GetChannelMembers(context.TODO(), channelID, idx, batchSize, "")
 		if err != nil {
 			shouldRetry, hErr := m.HandleRetry("UsernamesInChannel", retryCount, 10, resp)
@@ -380,6 +386,7 @@ func (m *Client) UsernamesInChannel(channelID string) []string {
 }
 
 func (m *Client) UpdateStatus(userID string, status string) error {
+	m.apiLogger.Warnf("UpdateStatus: UserID: %s, Status: %s", userID, status)
 	_, _, err := m.Client.UpdateUserStatus(context.TODO(), userID, &model.Status{Status: status})
 	if err != nil {
 		return err


### PR DESCRIPTION
We're using `"WARN"` level logging so it further stands out when combined with `logrus-prefixed-formatter` and `DisableColors: false`.

Default is `"ERROR"` so it's not enabled by default and not too noisy.

I'm currently running with this patch:

```
diff --git a/vendor/github.com/mattermost/mattermost-server/v6/model/client4.go b/vendor/github.com/mattermost/mattermost-server/v6/model/client4.go
index c6e7d88..2f8373b 100644
--- a/vendor/github.com/mattermost/mattermost-server/v6/model/client4.go
+++ b/vendor/github.com/mattermost/mattermost-server/v6/model/client4.go
@@ -593,6 +593,14 @@ func (c *Client4) DoAPIRequestBytes(method, url string, data []byte, etag string
 }

 func (c *Client4) DoAPIRequestReader(method, url string, data io.Reader, headers map[string]string) (*http.Response, error) {
+       fmt.Printf("\033[33mHAW: DoAPIRequestReader(): method: '%s' url: '%s' data: '???'\033[0m\n", method, url)
        rq, err := http.NewRequest(method, url, data)
        if err != nil {
                return nil, err
@@ -609,6 +617,10 @@ func (c *Client4) DoAPIRequestReader(method, url string, data io.Reader, headers
        if c.HTTPHeader != nil && len(c.HTTPHeader) > 0 {
                for k, v := range c.HTTPHeader {
                        rq.Header.Set(k, v)
+                       if !strings.HasSuffix(url, "system/ping") {
+                           fmt.Printf("\033[33mHAW: DoAPIRequestReader(): method: '%s' url: '%s' request headers: '%s' value: '%s'\033[0m\n", method, url, k, v)
+                       }
                }
        }
```

But I think it would be nice and useful for others to have this built into `matterclient`. Also, reduces a custom patch I have to carry locally.