### PR TITLE
Ensure we always retain a channels' LastPostAt

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -560,13 +560,13 @@ func (m *Client) UpdateChannelsTeam(ctx context.Context, teamID string) error {
 			if cached.Purpose != ch.Purpose {
 				cached.Purpose = ch.Purpose
 			}
-			if cached.UpdateAt != ch.UpdateAt {
+			if cached.UpdateAt < ch.UpdateAt {
 				cached.UpdateAt = ch.UpdateAt
 			}
 			if cached.DeleteAt != ch.DeleteAt {
 				cached.DeleteAt = ch.DeleteAt
 			}
-			if cached.LastPostAt != ch.LastPostAt {
+			if cached.LastPostAt < ch.LastPostAt {
 				cached.LastPostAt = ch.LastPostAt
 			}
 			if newType := internType(ch.Type); cached.Type != newType {
@@ -606,13 +606,13 @@ func (m *Client) UpdateChannelsTeam(ctx context.Context, teamID string) error {
 			if cached.Purpose != ch.Purpose {
 				cached.Purpose = ch.Purpose
 			}
-			if cached.UpdateAt != ch.UpdateAt {
+			if cached.UpdateAt < ch.UpdateAt {
 				cached.UpdateAt = ch.UpdateAt
 			}
 			if cached.DeleteAt != ch.DeleteAt {
 				cached.DeleteAt = ch.DeleteAt
 			}
-			if cached.LastPostAt != ch.LastPostAt {
+			if cached.LastPostAt < ch.LastPostAt {
 				cached.LastPostAt = ch.LastPostAt
 			}
 			if newType := internType(ch.Type); cached.Type != newType {


### PR DESCRIPTION
It is possible for the Mattermost /users/me/channels API endpoint to return 0 for last_post_at. Since we likely already have this value in our cache, use that if it's higher than what we've received to ensure it's more accurate for replaying channel history.

Per https://github.com/42wim/matterircd/pull/753