### PR TITLE
Comment on why we hardcode and use 200; it's a Mattermost hardcoded limit

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -183,7 +183,7 @@ func (m *Client) GetChannelUsers(ctx context.Context, channelID string) ([]*mode
 	}
 	m.Users.mu.RUnlock()
 
-	const batchSize = 200
+	const batchSize = mattermostPerPageMax
 	fetchedUsers := make([]UserSummary, 0, batchSize)
 
 	idx := 0
@@ -410,7 +410,7 @@ func (m *Client) JoinChannel(ctx context.Context, channelID string) error {
 
 //nolint:funlen,gocognit,gocyclo
 func (m *Client) UpdateChannelsTeam(ctx context.Context, teamID string) error {
-	const batchSize = 200
+	const batchSize = mattermostPerPageMax
 
 	var joinedSummaries []ChannelSummary
 	retryCount := 0

--- a/matterclient.go
+++ b/matterclient.go
@@ -148,6 +148,10 @@ type Client struct {
 
 var Matterircd bool
 
+// Mattermost has a hardcoded `PerPageMaximum = 200` & `LimitMaximum = 200`
+// See https://github.com/mattermost/mattermost/blob/master/server/channels/web/params.go
+const mattermostPerPageMax = 200
+
 func New(login string, pass string, team string, server string, mfatoken string) *Client {
 	// Logger for the rest of matterclient
 	rootLogger := logrus.New()
@@ -502,7 +506,7 @@ func (m *Client) initUser(ctx context.Context) error {
 		return err
 	}
 
-	const batchSize = 200
+	const batchSize = mattermostPerPageMax
 
 	for _, team := range teams {
 		if m.IsAborted(ctx) {

--- a/messages.go
+++ b/messages.go
@@ -106,7 +106,7 @@ func (m *Client) GetPost(ctx context.Context, postID string) (*model.Post, error
 }
 
 func (m *Client) GetPosts(ctx context.Context, channelID string, limit int) *model.PostList {
-	const batchSize = 200
+	const batchSize = mattermostPerPageMax
 
 	if limit <= 0 {
 		limit = 60

--- a/users.go
+++ b/users.go
@@ -240,7 +240,7 @@ func (m *Client) SetUserStatus(userID string, rawStatus string) string {
 
 //nolint:funlen,gocognit,gocyclo
 func (m *Client) UpdateUsers(ctx context.Context) error {
-	const batchSize = 200
+	const batchSize = mattermostPerPageMax
 
 	idx := 0
 	retryCount := 0
@@ -353,7 +353,7 @@ func (m *Client) UpdateUserNick(ctx context.Context, nick string) error {
 }
 
 func (m *Client) UsernamesInChannel(ctx context.Context, channelID string) []string {
-	const batchSize = 200
+	const batchSize = mattermostPerPageMax
 
 	allusers := m.GetUsers()
 	result := make([]string, 0, batchSize)


### PR DESCRIPTION
See https://github.com/mattermost/mattermost/blob/master/server/channels/web/params.go:

```
const (
	PageDefault        = 0
	PerPageDefault     = 60
	PerPageMaximum     = 200
	LogsPerPageDefault = 10000
	LogsPerPageMaximum = 10000
	LimitDefault       = 60
	LimitMaximum       = 200
)
```

It's also been discussed in https://github.com/42wim/matterircd/issues/479