### PR TITLE
Swap out initial syncing of user statuses from using the WebSocket GetStatuses to the HTTP API to ensure correctness

### DIFF
--- a/matterclient.go
+++ b/matterclient.go
@@ -303,6 +303,8 @@ func (m *Client) Login(ctx context.Context) error {
 		return err
 	}
 
+	_ = m.GetStatuses(ctx)
+
 	if m.Team == nil {
 		validTeamNames := make([]string, 0, len(m.OtherTeams))
 		for _, t := range m.OtherTeams {
@@ -333,11 +335,6 @@ func (m *Client) Login(ctx context.Context) error {
 	// They will run until m.loginCancel() is called during Logout.
 	//nolint:contextcheck
 	go m.WsReceiver(bgCtx)
-
-	if m.WsClient != nil {
-		m.logger.Trace("requesting initial user statuses for cache")
-		m.WsGetStatuses()
-	}
 
 	if m.OnWsConnect != nil {
 		m.logger.Trace("executing OnWsConnect()")

--- a/users.go
+++ b/users.go
@@ -176,7 +176,11 @@ func (m *Client) GetStatuses(ctx context.Context) map[string]string {
 
 		retryCount := 0
 		for {
-			m.apiLogger.Warnf("GetStatuses: GetUsersStatusesByIds: Batch: %d #%d", len(batch), retryCount)
+			if len(batch) <= 8 {
+				m.apiLogger.Warnf("GetStatuses: GetUsersStatusesByIds: Batch: %d %v #%d", len(batch), batch, retryCount)
+			} else {
+				m.apiLogger.Warnf("GetStatuses: GetUsersStatusesByIds: Batch: %d #%d", len(batch), retryCount)
+			}
 
 			res, resp, err := m.Client.GetUsersStatusesByIds(ctx, batch)
 			if err == nil {
@@ -204,7 +208,7 @@ func (m *Client) GetStatuses(ctx context.Context) map[string]string {
 
 	for _, id := range missingIDs {
 		if _, ok := statuses[id]; !ok {
-			statuses[id] = model.StatusOffline
+			statuses[id] = m.SetUserStatus(id, model.StatusOffline)
 		}
 	}
 


### PR DESCRIPTION
Per https://github.com/42wim/matterircd/pull/856