### PR TITLE
Add HttpPing to measure latency (PING) via HTTP REST API call

### DIFF
--- a/matterclient.go
+++ b/matterclient.go
@@ -1322,6 +1322,26 @@ func (m *Client) HandleRetry(ctx context.Context, name string, err error, curren
 	}
 }
 
+// HttpPing sends an HTTP API GET /api/v4/system/ping request and returns the server status.
+func (m *Client) HttpPing(ctx context.Context) (string, error) {
+	if m.Client == nil {
+		return "", errors.New("client not initialized")
+	}
+
+	m.logger.Trace("HttpPing: sending ping")
+
+	status, _, err := m.Client.GetPing(ctx)
+	if err != nil {
+		m.apiLogger.Warnf("HttpPing: GetPing: %#v", err)
+
+		return "", err
+	}
+
+	m.apiLogger.Infof("HttpPing: GetPing: %s", status)
+
+	return status, nil
+}
+
 // IsAborted checks if the user disconnected, logout was called, or the context died.
 func (m *Client) IsAborted(ctx context.Context) bool {
 	if m.WsQuit {


### PR DESCRIPTION
Per https://github.com/42wim/matterircd/pull/858

Also, latency checking across the WebSocket was already implemented in https://github.com/matterbridge/matterclient/pull/90, this adds the same/similar but over the HTTP REST API.